### PR TITLE
include ms in conversion of date to beats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ function wrap(beats: number): number {
 
 export function fromDate(date: Date, long?: boolean): string {
   const seconds =
+    (date.getUTCMilliseconds() / 1000) +
     date.getUTCSeconds() +
     (date.getUTCMinutes() * 60 + (date.getUTCHours() + 1) * 3600);
 


### PR DESCRIPTION
The current code tends to skip a hundredth of a beat during the conversion from seconds to beats. 
You can see this when stepping from 75762 seconds to 75763 seconds. The former is 876.87 beats while the later is 876.89 beats.
While it does not cause significant issues in terms of real world timing, when viewing a clock that displays hundredths of a beat this is easily noticeable and may imply a lower quality product.
By including the milliseconds in the calculation, the skipped hundredth of a beat is avoided.